### PR TITLE
chore: enable Dependabot for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: daily


### PR DESCRIPTION
Just like https://github.com/remix-run/indie-stack/pull/153, https://github.com/remix-run/blues-stack/pull/110 & https://github.com/remix-run/grunge-stack/pull/97