### PR TITLE
Remove dotfiles from `ignoredRouteFiles` in readme

### DIFF
--- a/packages/v1-route-convention/README.md
+++ b/packages/v1-route-convention/README.md
@@ -10,7 +10,7 @@ const { createRoutesFromFolders } = require("@remix-run/v1-route-convention");
 module.exports = {
   // Tell Remix to ignore everything in the routes directory.
   // We'll let `createRoutesFromFolders` take care of that.
-  ignoredRouteFiles: ["**/*", "**/.*"],
+  ignoredRouteFiles: ["**/*"],
   routes: (defineRoutes) => {
     // `createRoutesFromFolders` will create routes for all files in the
     // routes directory using the same default conventions as Remix v1.


### PR DESCRIPTION
This PR rolls back the docs update introduced in https://github.com/remix-run/v1-compat-utils/pull/42. This is now handled automatically in Remix v2.7.0.